### PR TITLE
fix a bug in bundle entropy for ICNN

### DIFF
--- a/agents/ICNN.py
+++ b/agents/ICNN.py
@@ -31,11 +31,10 @@ class InputConvexNetwork(object):
         self.episode_ave_max_q = 0.0
         self.graph = tf.Graph()
 
-        # k in the buddle entropy method
         self.inference_max_steps = config.inference_max_steps
 
-        # self.inference = 'bundle_entropy'
-        self.inference = 'adam'
+        self.inference = 'bundle_entropy'
+        # self.inference = 'adam'
 
         with self.graph.as_default():
             tf.set_random_seed(random_seed)

--- a/agents/network/entropy_network.py
+++ b/agents/network/entropy_network.py
@@ -102,7 +102,7 @@ class EntropyNetwork(BaseNetwork):
             if self.inference == 'bundle_entropy':
                 # q(s,a) = q(s,a) + h(a)
                 tmpA = tf.clip_by_value(self.rmapAction(action), 0.0001, 0.9999)
-                outputs = outputs - tf.reduce_sum(tmpA * tf.log(tmpA) - (1 - tmpA) * tf.log(1 - tmpA), reduction_indices = 1, keep_dims=True)
+                outputs = outputs + tf.reduce_sum(tmpA * tf.log(tmpA) + (1 - tmpA) * tf.log(1 - tmpA), reduction_indices = 1, keep_dims=True)
 
         return inputs, phase, action, outputs
 


### PR DESCRIPTION
Fix the tiny bug in the entropy implementation, which might be the reason why bundle entropy is not stable. 